### PR TITLE
CLC-4037 Followup: Dry up code, separate highest-10-sec graphs

### DIFF
--- a/app/html/test_comparison_graphs.html
+++ b/app/html/test_comparison_graphs.html
@@ -8,11 +8,14 @@
 
     function drawAllCharts() {
       drawErrors();
-      drawCPU();
-      drawMemory();
-      drawSession();
-      drawAcademics();
-      drawAPIEndpoints();
+      drawGeneric(convertDateTimes(tsung_test_data['highest_cpu']), 'Date', 'CPU %', 'CPU %', 'cpu_chart_div');
+      drawGeneric(convertDateTimes(tsung_test_data['lowest_memory']), 'Date', 'Lowest Available Memory (MB)', 'Lowest Available Memory', 'memory_chart_div');
+      drawGeneric(convertDateTimes(tsung_test_data['session_mean']), 'Date', 'Time (ms)', 'Overall Session Mean', 'session_chart_div');
+      drawGeneric(convertDateTimes(tsung_test_data['session_highest_10sec_mean']), 'Date', 'Time (ms)', 'Session Highest 10-sec Mean', 'session_highest_10sec_chart_div');
+      drawGeneric(convertDateTimes(tsung_test_data['tr_academics_mean']), 'Date', 'Time (ms)', 'tr_academics Mean', 'academics_chart_div');
+      drawGeneric(convertDateTimes(tsung_test_data['tr_academics_highest_10sec_mean']), 'Date', 'Time (ms)', 'tr_academics Highest 10-sec Mean', 'academics_highest_10sec_chart_div');
+      drawGeneric(convertDateTimes(tsung_test_data['tr_api_endpoints_mean']), 'Date', 'Time (ms)', 'tr_api_endpoints Mean', 'api_endpoints_chart_div');
+      drawGeneric(convertDateTimes(tsung_test_data['tr_api_endpoints_highest_10sec_mean']), 'Date', 'Time (ms)', 'tr_api_endpoints Highest 10-sec Mean', 'api_endpoints_highest_10sec_chart_div');
     }
 
     function drawErrors() {
@@ -37,116 +40,22 @@
 
       chart.draw(data, options);
     }
-    function drawCPU() {
 
+    function drawGeneric(input_data, x_axis, y_axis, title, div) {
       var data = new google.visualization.DataTable();
-      data.addColumn('datetime', 'Run Date');
-      data.addColumn('number', 'CPU %');
+      data.addColumn('datetime', x_axis);
+      data.addColumn('number', y_axis);
       data.addColumn({type: 'string', role: 'tooltip'});
-      data.addRows(convertDateTimes(tsung_test_data['highest_cpu']));
-
+      data.addRows(input_data);
       var options = {
-        title: 'CPU %',
-        hAxis: {title: 'Run Date'},
-        vAxis: {title: 'CPU %'},
-        curveType: 'function',
-        legend: { position: 'bottom' },
-        trendlines: { 0: {} }
-      };
-
-      var chart = new google.visualization.ScatterChart(document.getElementById('cpu_chart_div'));
-
-      chart.draw(data, options);
-    }
-
-    function drawMemory() {
-      var data = new google.visualization.DataTable();
-      data.addColumn('datetime', 'Run Date');
-      data.addColumn('number', 'Lowest Available Memory (MB)');
-      data.addColumn({type: 'string', role: 'tooltip'});
-      data.addRows(convertDateTimes(tsung_test_data['lowest_memory']));
-
-      var options = {
-        title: 'Lowest Available Memory',
-        hAxis: {title: 'Run Date'},
-        vAxis: {title: 'Memory (MB)'},
-        curveType: 'function',
-        legend: { position: 'bottom' },
-        trendlines: { 0: {} }
-      };
-
-      var chart = new google.visualization.ScatterChart(document.getElementById('memory_chart_div'));
-
-      chart.draw(data, options);
-    }
-
-
-    function drawSession() {
-      var data = new google.visualization.DataTable();
-      data.addColumn('datetime', 'Run Date');
-      data.addColumn('number', 'Session Mean (ms)');
-      data.addColumn({type: 'string', role: 'tooltip'});
-      data.addColumn('number', 'Highest 10-Second Mean (ms)');
-      data.addColumn({type: 'string', role: 'tooltip'});
-      data.addRows(convertDateTimes(tsung_test_data['session_mean']));
-
-      var options = {
-        title: 'Overall Session Mean and Highest 10-Second Mean',
-        hAxis: {title: 'Run Date'},
-        vAxis: {title: 'Time (ms)'},
+        title: title,
+        hAxis: {title: x_axis},
+        vAxis: {title: y_axis},
         curveType: 'function',
         legend: { position: 'bottom' },
         trendlines: { 0: {}, 1: {} }
       };
-
-      var chart = new google.visualization.ScatterChart(document.getElementById('session_chart_div'));
-
-      chart.draw(data, options);
-    }
-
-    function drawAcademics() {
-      var data = new google.visualization.DataTable();
-      data.addColumn('datetime', 'Run Date');
-      data.addColumn('number', 'Academics Mean (ms)');
-      data.addColumn({type: 'string', role: 'tooltip'});
-      data.addColumn('number', 'Highest 10-Second Mean (ms)');
-      data.addColumn({type: 'string', role: 'tooltip'});
-      data.addRows(convertDateTimes(tsung_test_data['tr_academics_mean']));
-
-      var options = {
-        title: 'Academics Mean and Highest 10-Second Mean',
-        hAxis: {title: 'Run Date'},
-        vAxis: {title: 'Time (ms)'},
-        curveType: 'function',
-        legend: { position: 'bottom' },
-        trendlines: { 0: {}, 1: {} }
-      };
-
-      var chart = new google.visualization.ScatterChart(document.getElementById('academics_chart_div'));
-
-      chart.draw(data, options);
-    }
-
-    function drawAPIEndpoints() {
-      var data = new google.visualization.DataTable();
-      data.addColumn('datetime', 'Run Date');
-      data.addColumn('number', 'API Endpoints Mean (ms)');
-      data.addColumn({type: 'string', role: 'tooltip'});
-      data.addColumn('number', 'Highest 10-Second Mean (ms)');
-      data.addColumn({type: 'string', role: 'tooltip'});
-      data.addRows(convertDateTimes(tsung_test_data['tr_api_endpoints_mean']));
-
-      var options = {
-        title: 'API Endpoints Mean and Highest 10-Second Mean',
-        hAxis: {title: 'Run Date'},
-        vAxis: {title: 'Time (ms)'},
-        curveType: 'function',
-        legend: { position: 'bottom' },
-        trendlines: { 0: {}, 1: {} }
-      };
-
-      var chart = new google.visualization.ScatterChart(document.getElementById('api_endpoints_chart_div'));
-
+      var chart = new google.visualization.ScatterChart(document.getElementById(div));
       chart.draw(data, options);
     }
 
@@ -168,13 +77,19 @@
 
 <div id="cpu_chart_div" style="width: 800px; height: 400px; display:inline-block"></div>
 
+<div id="memory_chart_div" style="width: 1200px; height: 400px; display:inline-block"></div>
+
 <div id="session_chart_div" style="width: 1200px; height: 400px; display:inline-block"></div>
 
-<div id="memory_chart_div" style="width: 1200px; height: 400px; display:inline-block"></div>
+<div id="session_highest_10sec_chart_div" style="width: 1200px; height: 400px; display:inline-block"></div>
 
 <div id="academics_chart_div" style="width: 1200px; height: 400px; display:inline-block"></div>
 
+<div id="academics_highest_10sec_chart_div" style="width: 1200px; height: 400px; display:inline-block"></div>
+
 <div id="api_endpoints_chart_div" style="width: 1200px; height: 400px; display:inline-block"></div>
+
+<div id="api_endpoints_highest_10sec_chart_div" style="width: 1200px; height: 400px; display:inline-block"></div>
 
 </body>
 </html>

--- a/app/load_tests/google_charts_json_converter.rb
+++ b/app/load_tests/google_charts_json_converter.rb
@@ -9,9 +9,12 @@ module LoadTests
         highest_cpu: [],
         lowest_memory: [],
         session_mean: [],
+        session_highest_10sec_mean: [],
         error_count: [],
         tr_academics_mean: [],
-        tr_api_endpoints_mean: []
+        tr_academics_highest_10sec_mean: [],
+        tr_api_endpoints_mean: [],
+        tr_api_endpoints_highest_10sec_mean: []
       }
 
       @results.keys.sort.each do |key|
@@ -30,7 +33,15 @@ module LoadTests
         if @results[key][:session].present?
           json[:session_mean] << [
             @results[key][:run_date],
-            @results[key][:session][:mean], "#{key}: #{@results[key][:session][:mean]}ms",
+            @results[key][:session][:mean], "#{key}: #{@results[key][:session][:mean]}ms"
+          ]
+        end
+      end
+
+      @results.keys.sort.each do |key|
+        if @results[key][:session].present?
+          json[:session_highest_10sec_mean] << [
+            @results[key][:run_date],
             @results[key][:session][:highest_10sec_mean], "#{key}: #{@results[key][:session][:highest_10sec_mean]}ms"
           ]
         end
@@ -60,7 +71,15 @@ module LoadTests
         if @results[key][:tr_academics].present?
           json[:tr_academics_mean] << [
             @results[key][:run_date],
-            @results[key][:tr_academics][:mean], "#{key}: #{@results[key][:tr_academics][:mean]}ms",
+            @results[key][:tr_academics][:mean], "#{key}: #{@results[key][:tr_academics][:mean]}ms"
+          ]
+        end
+      end
+
+      @results.keys.sort.each do |key|
+        if @results[key][:tr_academics].present?
+          json[:tr_academics_highest_10sec_mean] << [
+            @results[key][:run_date],
             @results[key][:tr_academics][:highest_10sec_mean], "#{key}: #{@results[key][:tr_academics][:highest_10sec_mean]}ms"
           ]
         end
@@ -70,7 +89,15 @@ module LoadTests
         if @results[key][:tr_api_endpoints].present?
           json[:tr_api_endpoints_mean] << [
             @results[key][:run_date],
-            @results[key][:tr_api_endpoints][:mean], "#{key}: #{@results[key][:tr_api_endpoints][:mean]}ms",
+            @results[key][:tr_api_endpoints][:mean], "#{key}: #{@results[key][:tr_api_endpoints][:mean]}ms"
+          ]
+        end
+      end
+
+      @results.keys.sort.each do |key|
+        if @results[key][:tr_api_endpoints].present?
+          json[:tr_api_endpoints_highest_10sec_mean] << [
+            @results[key][:run_date],
             @results[key][:tr_api_endpoints][:highest_10sec_mean], "#{key}: #{@results[key][:tr_api_endpoints][:highest_10sec_mean]}ms"
           ]
         end

--- a/spec/load_tests/google_charts_json_converter_spec.rb
+++ b/spec/load_tests/google_charts_json_converter_spec.rb
@@ -15,13 +15,15 @@ describe LoadTests::GoogleChartsJsonConverter do
     expect(subject[:lowest_memory][0][1]).to eq 3852.1
     expect(subject[:session_mean][0][0]).to eq 1411394598
     expect(subject[:session_mean][0][1]).to eq 95596.7
-    expect(subject[:session_mean][0][3]).to eq 113181.9
+    expect(subject[:session_highest_10sec_mean][0][1]).to eq 113181.9
     expect(subject[:error_count][0][0]).to eq 1411394598
     expect(subject[:error_count][0][1]).to eq 37
     expect(subject[:tr_academics_mean][0][0]).to eq 1411394598
     expect(subject[:tr_academics_mean][0][1]).to eq 115.5
+    expect(subject[:tr_academics_highest_10sec_mean][0][1]).to eq 389.4
     expect(subject[:tr_api_endpoints_mean][0][0]).to eq 1411394598
     expect(subject[:tr_api_endpoints_mean][0][1]).to eq 9800.3
+    expect(subject[:tr_api_endpoints_highest_10sec_mean][0][1]).to eq 29273.6
   }
 
 end


### PR DESCRIPTION
Trends are more obvious when the highest-10-sec numbers are split into their own charts. JS code refactored to reduce duplication. 
